### PR TITLE
Potentiometer

### DIFF
--- a/philander/mcp40d.py
+++ b/philander/mcp40d.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Driver implementation for the MCP40D 17/18/19 digital potentiometers.
+
+More information on the functionality of the chip can be found at
+the microchip's site for the 18 series chip with download for data sheet of all three chips:
+https://www.microchip.com/en-us/product/MCP40D18
+"""
+__author__ = "Carl Bellgardt"
+__version__ = "0.1"
+__all__ = ["MCP40D"]
+
+import time
+from enum import unique, auto, Enum
+
+from .potentiometer import Potentiometer
+from .serialbus import SerialBusDevice
+from .systypes import ErrorCode, RunLevel
+
+'''
+@unique
+class PackageTypes(Enum):
+    """Data class to decide which PackageType of sensor is being
+    """
+    MCP40D17 = auto()
+    MCP40D18 = auto()
+    MCP40D19 = auto()
+    
+@unique
+class ResistanceCode(Enum):
+    """Data class to decide which resistance code the device has\
+    and which resistance thus must be it's maximum value.
+    """
+    _502 = 5000
+    _103 = 10000
+    _503 = 50000
+    _104 = 100000
+'''
+
+class MCP40D( SerialBusDevice, Potentiometer ):
+    """MCP40D17/18/19 driver implementation.
+
+    The CMP40D17/18/19 chips are digital potentiometers that are controlled via an I2C interface. Their difference lies in their terminal configurations.
+    The all come in different resistances of 5kOhm, 10kOhm, 50kOhm and 100kOhm. Read more under https://www.microship.com/en-us/product/MCP40D17
+    """
+    
+    ADDRESSES_ALLOWED = [0x2E, 0x3E]
+    _potentiometer_resolution = None
+    _potentiometer_resistance_max = None
+
+    def __init__(self):
+        # Create instance attributes and initialize parent classes and interfaces
+        SerialBusDevice.__init__(self)
+        Potentiometer.__init__(self)
+
+    #
+    # Module API
+    #
+
+    @classmethod
+    def Params_init(cls, paramDict):
+        """Initializes configuration parameters with defaults.
+        
+        The following settings are supported:
+        
+        =============================    ==========================================================================================================
+        Key name                         Value type, meaning and default
+        =============================    ==========================================================================================================
+        SerialBusDevice.address          ``int`` I2C serial device address; default is :attr:`ADDRESSES_ALLOWED` [0].
+        Potentiometer.resistance.max     ``int``; Maximum resistance in Ohm; :attr:`DEFAULT_RESISTANCE_MAX`.
+        Potentiometer.resolution         ``int``; Number of bits used to set resistance value.
+        ===========================================================================================================================================
+        
+        For the ``SerialBusDevice.address`` value, also 0 or 1
+        can be specified alternatively to the absolute addresses to reflect
+        the level of the ``SDO`` pin. In this case, 0 will be mapped to
+        0x18, while 1 maps to 0x19.
+        
+        Also see: :meth:`.SerialBusDevice.Params_init`, :meth:`.Potentiometer.Params_init`. 
+        """
+        defaults = dict()
+        SerialBusDevice.Params_init( paramDict )
+        Potentiometer.Params_init( paramDict )
+        defaults.update( paramDict )
+        paramDict = defaults
+        return None
+
+    def open(self, paramDict):
+        """Initialize an instance and prepare it for use.
+
+        Also see: :meth:`.Module.open`.
+        
+        :param dict(str, object) paramDict: Configuration parameters as\
+        possibly obtained from :meth:`Params_init`.
+        :return: An error code indicating either success or the reason of failure.
+        :rtype: ErrorCode
+        """
+        # Get default parameters
+        MCP40D.Params_init( paramDict )
+        # Open the bus device
+        ret = SerialBusDevice.open(self, paramDict)
+        # Store potentiometer properties
+        self._potentiometer_resolution = paramDict["Potentiometer.resolution"]
+        self._potentiometer_resistance_max = paramDict["Potentiometer.resistance.max"]
+        return ret
+
+
+    def close(self):
+        """Close this instance and release hardware resources.
+        
+        Also see: :meth:`.Module.close`.
+        
+        :return: An error code indicating either success or the reason of failure.
+        :rtype: ErrorCode
+        """
+        ret = super().close()
+        return ret
+    
+    def set(self, value, isAbsolute=False, isDigital=False):
+        """Set resistance of potentiometer to a relative (percentage) or absolute (Ohms) value via I2C.
+        
+        Also see: :meth:`.Potentiometer.set`.
+        
+        :param int value: Resistance value, interpreted as percentage (0 to 100) by default.\
+        Will be inpreted as absolute resistance in ohms, if isAbsolute is set true,\
+        or as digital value if isDigital is true.
+        :param bool isAbsolute: Set true if value is in ohms.
+        :return: An error code indicating either success or the reason of failure.
+        :rtype: ErrorCode
+        """
+        value = Potentiometer._digitalize_resistance_value(value, isAbsolute, self._potentiometer_resistance_max, isDigital, self._potentiometer_resolution)
+        print(value)
+        err = SerialBusDevice.writeByteRegister(self, 0x00, value)
+        return err
+    
+    def get(self, asAbsolute=False, asDigital=False):
+        """Get current resistance setting of potentiometer as relative (percentage) or absolute (Ohms) or digital value via I2C.
+        
+        Also see: :meth:`.Potentiometer.get`.
+        
+        :param bool asAblsolute: Set true to convert value into ohms. False for a percentage value (default).
+        :param bool asDigital: Set true to return value as digital value.
+        :return: The resistance value and an error code indicating either success or the reason of failure.
+        :rtype: ErrorCode
+        """
+        data, err = SerialBusDevice.readByteRegister(self, 0x00)
+        if asDigital:
+            return data, err
+        # convert data into percentage or ohms
+        pot_steps = 2 ** self._potentiometer_resolution # number of available steps, dependent on number of bits for resolution
+        if asAbsolute:
+            data *= (self._potentiometer_resistance_max / pot_steps)
+        else:
+            data *= (100/pot_steps)
+        return data, err
+    
+    def _get_digital(self):
+         data, err = SerialBusDevice.readByteRegister(self, 0x00)
+         return data, err

--- a/philander/mcp40d.py
+++ b/philander/mcp40d.py
@@ -81,7 +81,7 @@ class MCP40D( SerialBusDevice, Potentiometer ):
         :return: An error code indicating either success or the reason of failure.
         :rtype: ErrorCode
         """
-        ret = super().close()
+        ret = SerialBusDevice.close(self)
         return ret
     
     def _digitalize_resistance_value(self, percentage=None, absolute=None, digital=None): 

--- a/philander/potentiometer.py
+++ b/philander/potentiometer.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""A module to provide a base class for potentiometer driver implementations.
+"""
+__author__ = "Carl Bellgardt"
+__version__ = "0.1"
+__all__ = []
+
+from .primitives import Voltage, Percentage
+from .systypes import ErrorCode, Info
+from .module import Module
+
+class Potentiometer( Module ):
+    """Generic digital potentiometer driver class.
+
+    A digital potentiometer is able to adjust a resistance divider's wiper by sending a resistance value to set digitalky, e.g. using I2C.\
+    It can be used as a variable resistor or for more complex things. Depending on the specific ship it can feature different terminals\
+    to make use of it's resistance divider functionality.
+    """
+    
+    DEFAULT_RESISTANCE_MAX = 10000
+    DEFAULT_RESOLUTION = 7
+    
+    @classmethod
+    def Params_init(cls, paramDict):
+        """Initializes configuration parameters with defaults.
+        
+        The following settings are supported:
+        
+        =============================    =====================================================================================================
+        Key name                         Value type, meaning and default
+        =============================    =====================================================================================================
+        Potentiometer.resistance.max     ``int``; Maximum resistance in Ohm; :attr:`DEFAULT_RESISTANCE_MAX`.
+        Potentiometer.resolution         ``int``; Number of bits used to set resistance value.
+        ======================================================================================================================================
+        """
+        defaults = {
+            "Potentiometer.resistance.max": Potentiometer.DEFAULT_RESISTANCE_MAX,
+            "Potentiometer.resolution": Potentiometer.DEFAULT_RESOLUTION
+        }
+        defaults.update(paramDict)
+        paramDict = defaults
+        return None
+    
+    def open(self, paramDict):
+        """Initialize an instance and prepare it for use.
+
+        Also see: :meth:`.Module.open`.
+        
+        :param dict(str, object) paramDict: Configuration parameters as\
+        possibly obtained from :meth:`Params_init`.
+        :return: An error code indicating either success or the reason of failure.
+        :rtype: ErrorCode
+        """
+        return NotImplementedError
+        
+    def close(self, paramDict):
+        """Close this instance and release hardware resources.
+        
+        Also see: :meth:`.Module.close`.
+        
+        :return: An error code indicating either success or the reason of failure.
+        :rtype: ErrorCode
+        """
+        return NotImplementedError
+    
+    def _digitalize_resistance_value(value, isAbsolute=False, max_resistance=None, isDigital=False, resolution=None):
+        """Converts an either digital, absolute or relative resistance value into a digital value. It also checks for it's validity.
+
+        Also see: :meth:`.potentiometer._eval_resistance_value`.
+        
+        :param int value: Resistance value, interpreted as percentage (0 to 100) by default.\
+        Will be inpreted as absolute resistance in ohms, if isAbsolute is set true.
+        :param bool isAbsolute: Set true if value is in ohms.
+        :return: An error code indicating either success or the reason of failure.
+        :rtype: int
+        """
+        Potentiometer._eval_resistance_value(value, isAbsolute, max_resistance, isDigital, resolution)
+        pot_steps = 2 ** resolution # number of available steps, dependent on number of bits for resolution
+        if isAbsolute:
+            return round((value / max_resistance) * (pot_steps - 1))
+        elif isDigital:
+            return value
+        else:
+            return round((value / 100) * (pot_steps - 1))
+    
+    def _eval_resistance_value(value, isAbsolute=False, max_resistance=None, isDigital=False, resolution=None):
+        """Evaluate values given to set method. Raises error if values are invalid (e.g. over 100% or over maximum resistance).
+        
+        :param int value: Resistance value, interpreted as percentage (0 to 100) by default.\
+        Will be inpreted as absolute resistance in ohms, if isAbsolute is set true.
+        :param bool isAbsolute: Set true if value is in ohms.
+        :return: An error code indicating either success or the reason of failure.
+        :rtype: None
+        """
+        if isAbsolute and (value < 0 or value > max_resistance):
+            print(f"Given absolute resistance value was {value} ohm must be between 0 ohm and the given maximum ({max_resistance} is currently set)")
+            raise ValueError
+        elif isDigital and (value < 0 or value >= (2**resolution)):
+            print(f"Digital value must be between 0 and the given resolution (currently {resolution} bit -> {2**resolution}).")
+            raise ValueError
+        elif not isAbsolute and not isDigital and (value < 0 or value > 100):
+            print("Percentage value must be between 0 and 100.")
+            raise ValueError
+        return None
+    
+    def set(self, value, isAbsolute=False):
+        """Set resistance of potentiometer to a relative (percentage) or absolute (ohms) value.
+        
+        :param int value: Resistance value, interpreted as percentage (0 to 100) by default.\
+        Will be inpreted as absolute resistance in ohms, if isAbsolute is set true.
+        :param bool isAbsolute: Set true if value is in ohms.
+        :return: An error code indicating either success or the reason of failure.
+        :rtype: ErrorCode
+        """
+        self.__eval_resistance_value(value, isAbsolute, max_resistance)
+        return NotImplementedError
+        
+        
+            

--- a/philander/potentiometer.py
+++ b/philander/potentiometer.py
@@ -5,20 +5,20 @@ __author__ = "Carl Bellgardt"
 __version__ = "0.1"
 __all__ = []
 
-from .primitives import Voltage, Percentage
-from .systypes import ErrorCode, Info
+from .primitives import Percentage
+from .systypes import ErrorCode
 from .module import Module
 
 class Potentiometer( Module ):
     """Generic digital potentiometer driver class.
 
     A digital potentiometer is able to adjust a resistance divider's wiper by sending a resistance value to set digitalky, e.g. using I2C.\
-    It can be used as a variable resistor or for more complex things. Depending on the specific ship it can feature different terminals\
+    It can be used as a variable resistor or for more complex things. Depending on the specific chip it can feature different terminals\
     to make use of it's resistance divider functionality.
     """
     
     DEFAULT_RESISTANCE_MAX = 10000
-    DEFAULT_RESOLUTION = 128
+    DEFAULT_digital_max = 128
     
     @classmethod
     def Params_init(cls, paramDict):
@@ -29,13 +29,13 @@ class Potentiometer( Module ):
         =============================    =====================================================================================================
         Key name                         Value type, meaning and default
         =============================    =====================================================================================================
-        Potentiometer.resistance.max     ``int``; Maximum resistance in Ohm; :attr:`DEFAULT_RESISTANCE_MAX`.
-        Potentiometer.resolution         ``int``; Number of possible steps to set resistance value to (2^(bits used for resistance)). :attr:`DEFAULT_RESOLUTION`.
+        Potentiometer.resistance.max     ``int`` Maximum resistance in Ohm; :attr:`DEFAULT_RESISTANCE_MAX`.
+        Potentiometer.digital_max         ``int`` Number of possible steps to set resistance value to (2^(bits used for resistance)). :attr:`DEFAULT_digital_max`.
         ======================================================================================================================================
         """
         defaults = {
             "Potentiometer.resistance.max": Potentiometer.DEFAULT_RESISTANCE_MAX,
-            "Potentiometer.resolution": Potentiometer.DEFAULT_RESOLUTION
+            "Potentiometer.digital_max": Potentiometer.DEFAULT_digital_max
         }
         defaults.update(paramDict)
         paramDict = defaults
@@ -51,7 +51,7 @@ class Potentiometer( Module ):
         :return: An error code indicating either success or the reason of failure.
         :rtype: ErrorCode
         """
-        return NotImplementedError
+        return ErrorCode.errNotImplemented
         
     def close(self, paramDict):
         """Close this instance and release hardware resources.
@@ -61,9 +61,9 @@ class Potentiometer( Module ):
         :return: An error code indicating either success or the reason of failure.
         :rtype: ErrorCode
         """
-        return NotImplementedError
+        return ErrorCode.errNotImplemented
     
-    def _digitalize_resistance_value(percentage=None, absolute=None, digital=None, resolution=None, max_resistance=None): 
+    def _digitalize_resistance_value(percentage=None, absolute=None, digital=None, digital_max=None, max_resistance=None): 
         """Converts an either digital, absolute or relative resistance value into a digital value. It also checks for it's validity.\
         There must only be one out of the parameters percentage, absolute and digital given.
         
@@ -72,46 +72,46 @@ class Potentiometer( Module ):
         :param percentage percentage: Resistance value, interpreted as percentage (0 to 100) by default.
         :param int absolute: Resistance value in Ohms. Must be between 0 and the set maximum value.
         :param int digital: Digital resistance value to be sent directly to the potentiometer without conversion.
-        :param int resolution: Number of possible steps to set resistance value to (2^(bits used for resistance)).
+        :param int digital_max: Number of possible steps to set resistance value to (2^(bits used for resistance)).
         :param int max_resistance: Maximum resistance of Potentiometer in Ohm.
         :return: An error code indicating either success or the reason of failure.
-        :rtype: None
+        :rtype: Tuple(value, ErrorCode)
         """
-        err = Potentiometer._eval_resistance_value(percentage, absolute, digital, resolution, max_resistance)
-        if err:
-            return None, err
-        elif percentage != None:
-            val = resolution * percentage // 100
-            return min(val, resolution-1), err
-        elif absolute != None:
-            val = resolution * percentage // max_resistance
-            return min(val, resolution-1), err
-        elif digital != None:
-            return digital, err
-        return None, Exception("What happened here?")
+        val = None
+        err = Potentiometer._eval_resistance_value(percentage, absolute, digital, digital_max, max_resistance)
+        if err == ErrorCode.errOk:
+            if percentage != None:
+                val = (digital_max * percentage) // 100
+            elif absolute != None:
+                val = int(digital_max * absolute) // max_resistance
+            elif digital != None:
+                pass
+            val = (digital_max-1) if val > (digital_max-1) else val
+        return val, err
     
-    def _eval_resistance_value(percentage=None, absolute=None, digital=None, resolution=None, max_resistance=None):
+    def _eval_resistance_value(percentage=None, absolute=None, digital=None, digital_max=None, max_resistance=None):
         """Evaluate values given to set method. Raises error if values are invalid (e.g. over 100% or over maximum resistance).\
         There must only be one out of the parameters percentage, absolute and digital given.
 
         :param percentage percentage: Resistance value, interpreted as percentage (0 to 100) by default.
         :param int absolute: Resistance value in Ohms. Must be between 0 and the set maximum value.
         :param int digital: Digital resistance value to be sent directly to the potentiometer without conversion.
-        :param int resolution: Number of possible steps to set resistance value to (2^(bits used for resistance)).
+        :param int digital_max: Number of possible steps to set resistance value to (2^(bits used for resistance)).
         :param int max_resistance: Maximum resistance of Potentiometer in Ohm.
         :return: An error code indicating either success or the reason of failure.
-        :rtype: None
+        :rtype: ErrorCode
         """
+        err = ErrorCode.errOk
         if (percentage != None) ^ bool(absolute != None) ^ bool(digital != None): # check if exactly one parameter is given
             if percentage and (percentage < 0 or percentage > 100):
-                raise ValueError("Percentage value must be between 0 and 100.")
+                err = ErrorCode.errInvalidParameter # Percentage value must be between 0 and 100.
             elif absolute and (absolute < 0 or absolute > max_resistance):
-                raise ValueError(f"Given absolute resistance value was {value} ohm must be between 0 ohm and the given maximum ({max_resistance} is currently set)")
-            elif digital and (digital < 0 or digital >= (resolution-1)):
-                raise ValueError(f"Digital value must be between 0 and the given resolution.")
-            return None
+                err = ErrorCode.errInvalidParameter # Given absolute resistance value was {value} ohm must be between 0 ohm and the given maximum ({max_resistance} is currently set)
+            elif digital and (digital < 0 or digital >= (digital_max-1)):
+                err = ErrorCode.errInvalidParameter # Digital value must be between 0 and the given digital_max.
         else:
-            return ValueError("There must only be one parameter given.")
+            err = ErrorCode.errInvalidParameter # There must only be one parameter given.
+        return err
     
     def set(self, percentage=None, absolute=None, digital=None):
         """Set resistance of potentiometer to a relative (percentage), absolute (ohms), or digital value.\
@@ -124,8 +124,7 @@ class Potentiometer( Module ):
         :return: An error code indicating either success or the reason of failure.
         :rtype: ErrorCode
         """
-        self.__eval_resistance_value(value, isAbsolute, max_resistance)
-        return NotImplementedError
+        return ErrorCode.errNotImplemented
     
     def get(self, asPercentage=True, asAbsolute=False, asDigital=False):
         """Get current resistance setting of potentiometer as ative (percentage), absolute (ohms), or digital value.\
@@ -137,7 +136,7 @@ class Potentiometer( Module ):
         :return: The resistance value and an error code indicating either success or the reason of failure.
         :rtype: ErrorCode
         """
-        return NotImplementedError
+        return ErrorCode.errNotImplemented
         
         
             

--- a/philander/potentiometer.py
+++ b/philander/potentiometer.py
@@ -79,14 +79,16 @@ class Potentiometer( Module ):
         """
         err = Potentiometer._eval_resistance_value(percentage, absolute, digital, resolution, max_resistance)
         if err:
-            return err, None
-        elif percentage:
-            return None, round((percentage / 100) * (resolution - 1)) # TODO: rethink this formular for equistant steps
-        elif absolute:
-            return None, round((absolute / max_resistance) * (resolution - 1)) # TODO: rethink this formular for equistant steps
-        elif digital:
-            return None, digital
-        return None
+            return None, err
+        elif percentage != None:
+            val = resolution * percentage // 100
+            return min(val, resolution-1), err
+        elif absolute != None:
+            val = resolution * percentage // max_resistance
+            return min(val, resolution-1), err
+        elif digital != None:
+            return digital, err
+        return None, Exception("What happened here?")
     
     def _eval_resistance_value(percentage=None, absolute=None, digital=None, resolution=None, max_resistance=None):
         """Evaluate values given to set method. Raises error if values are invalid (e.g. over 100% or over maximum resistance).\
@@ -100,7 +102,7 @@ class Potentiometer( Module ):
         :return: An error code indicating either success or the reason of failure.
         :rtype: None
         """
-        if bool(percentage) ^ bool(absolute) ^ bool(digital): # check if exactly one parameter is given
+        if (percentage != None) ^ bool(absolute != None) ^ bool(digital != None): # check if exactly one parameter is given
             if percentage and (percentage < 0 or percentage > 100):
                 raise ValueError("Percentage value must be between 0 and 100.")
             elif absolute and (absolute < 0 or absolute > max_resistance):

--- a/philander/primitives.py
+++ b/philander/primitives.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""A module t reflect fundamental physical units and scales.
+"""A module to reflect fundamental physical units and scales.
 """
 __author__ = "Oliver Maye"
 __version__ = "0.1"
@@ -28,7 +28,7 @@ class Temperature(int):
     invalid = -128
 
 class PreciseTemperature(int):
-    """Temperature [-70...+125]in degree Celsius [°C], given a s a\
+    """Temperature [-70...+125]in degree Celsius [°C], given as a\
     Q8.8 fixed-point number with 8-bit decimals.
     """
     invalid = -32768

--- a/philander/serialbus.py
+++ b/philander/serialbus.py
@@ -1064,7 +1064,7 @@ class SerialBus( _SerialBusIface ):
                 ret = SerialBusProvider.SMBUS2
             except ModuleNotFoundError:
                 try:
-                    from smbus import SMBus, i2c_msg
+                    from smbus import SMBus
                     ret = SerialBusProvider.SMBUS
                 except ModuleNotFoundError:
                     try:

--- a/test/testAccel.py
+++ b/test/testAccel.py
@@ -72,8 +72,7 @@ def sopen():
             else:
                 print("Error: ", err)
         except Exception as exc:
-            print("Exception:", exc)
-            #traceback.print_exc()
+            print(f"{type(exc).__name__}: {exc}")
     return None
 
 def sclose():

--- a/test/testPotentiometer.py
+++ b/test/testPotentiometer.py
@@ -14,7 +14,7 @@ def main():
         "SerialBus.designator": "/dev/i2c-1",
         "SerialBusDevice.address": 0x2E,
         "Potentiometer.resistance.max": 100000,
-        "Potentiometer.resolution": 7
+        "Potentiometer.resolution": 128
         }
     pot_steps = 2 ** conf["Potentiometer.resolution"]
     err_counter = 0
@@ -36,7 +36,7 @@ def main():
         if err != ErrorCode.errOk:
             print(f"Error while get(): {err}")
             err_counter += 1
-        expected_val = Potentiometer._digitalize_resistance_value(i, resolution=conf["Potentiometer.resolution"])
+        expected_val = poti._digitalize_resistance_value(percentage=i) # TODO: do with actual percentage value
         actual_val = data
         expected_val_percent = i
         actual_val_percent = (data * 100) / (pot_steps - 1)
@@ -62,7 +62,7 @@ def main():
         if err != ErrorCode.errOk:
             print(f"Error while get(): {err}")
             err_counter += 1
-        expected_val = Potentiometer._digitalize_resistance_value(i, isAbsolute=True, max_resistance=conf["Potentiometer.resistance.max"], resolution=conf["Potentiometer.resolution"])
+        expected_val = poti._digitalize_resistance_value(absolute=i)
         actual_val = data
         expected_val_ohms = i
         actual_val_ohms = data * (conf['Potentiometer.resistance.max'] / pot_steps)

--- a/test/testPotentiometer.py
+++ b/test/testPotentiometer.py
@@ -7,8 +7,8 @@ from philander.mcp40d import MCP40D as potentiometer
 from philander.potentiometer import Potentiometer
 from philander.primitives import Percentage
 
-WAIT_BETWEEN_SET_GET = .1#.5
-WAIT_BETWEEN_NEXT_TEST = .1#2.5
+WAIT_BETWEEN_SET_GET = .5
+WAIT_BETWEEN_NEXT_TEST = 2.5
 
 def main():
     conf = {

--- a/test/testPotentiometer.py
+++ b/test/testPotentiometer.py
@@ -5,6 +5,7 @@ from philander.systypes import ErrorCode
 # Replace this with any other potentiometer to test (conf might need to be adjusted accordingly)
 from philander.mcp40d import MCP40D as potentiometer
 from philander.potentiometer import Potentiometer
+from philander.primitives import Percentage
 
 WAIT_BETWEEN_SET_GET = .5
 WAIT_BETWEEN_NEXT_TEST = 2.5
@@ -15,8 +16,7 @@ def main():
         "SerialBusDevice.address": 0x2E,
         "Potentiometer.resistance.max": 100000,
         "Potentiometer.resolution": 128
-        }
-    pot_steps = 2 ** conf["Potentiometer.resolution"]
+        } 
     err_counter = 0
     
     poti = potentiometer()
@@ -24,7 +24,7 @@ def main():
     
     # test percentage values from 0 to 100 in steps of 10
     for i in range(0, 110, 10):
-        err = poti.set(i)
+        err = poti.set(percentage=Percentage(i))
         if err != ErrorCode.errOk:
             print(f"Error while set(): {err}")
             err_counter += 1
@@ -36,10 +36,10 @@ def main():
         if err != ErrorCode.errOk:
             print(f"Error while get(): {err}")
             err_counter += 1
-        expected_val = poti._digitalize_resistance_value(percentage=i) # TODO: do with actual percentage value
+        expected_val, _ = poti._digitalize_resistance_value(percentage=Percentage(i))
         actual_val = data
         expected_val_percent = i
-        actual_val_percent = (data * 100) / (pot_steps - 1)
+        actual_val_percent = data * (100/conf["Potentiometer.resolution"])
         
         if actual_val == expected_val:
             print(f"Read value is correct.")
@@ -47,10 +47,10 @@ def main():
             print(f"VALUE NOT CORRECT: Potentiometer resistance value should be {expected_val} ({round(expected_val_percent, 1)}%) but is set to {actual_val} ({round(actual_val_percent, 1)}%)")
         sleep(WAIT_BETWEEN_NEXT_TEST)
     
-    # test resistance values from 0 to <max> in steps of 10% * <max>
+    # test resistance values from 0 to <max> in steps of 10% in absolute resistance<max>
     for n in range(0, 110, 10):
         i = (n/100) * conf["Potentiometer.resistance.max"]
-        err = poti.set(i, isAbsolute=True)
+        err = poti.set(absolute=i)
         if err != ErrorCode.errOk:
             print(f"Error while set(): {err}")
             err_counter += 1
@@ -62,10 +62,10 @@ def main():
         if err != ErrorCode.errOk:
             print(f"Error while get(): {err}")
             err_counter += 1
-        expected_val = poti._digitalize_resistance_value(absolute=i)
+        expected_val, _ = poti._digitalize_resistance_value(absolute=i)
         actual_val = data
         expected_val_ohms = i
-        actual_val_ohms = data * (conf['Potentiometer.resistance.max'] / pot_steps)
+        actual_val_ohms = data * (conf['Potentiometer.resistance.max'] / conf["Potentiometer.resolution"])
         
         if actual_val == expected_val:
             print(f"Read value is correct.")

--- a/test/testPotentiometer.py
+++ b/test/testPotentiometer.py
@@ -1,0 +1,82 @@
+from time import sleep
+from philander.serialbus import SerialBusDevice
+from philander.systypes import ErrorCode
+
+# Replace this with any other potentiometer to test (conf might need to be adjusted accordingly)
+from philander.mcp40d import MCP40D as potentiometer
+from philander.potentiometer import Potentiometer
+
+WAIT_BETWEEN_SET_GET = .5
+WAIT_BETWEEN_NEXT_TEST = 2.5
+
+def main():
+    conf = {
+        "SerialBus.designator": "/dev/i2c-1",
+        "SerialBusDevice.address": 0x2E,
+        "Potentiometer.resistance.max": 100000,
+        "Potentiometer.resolution": 7
+        }
+    pot_steps = 2 ** conf["Potentiometer.resolution"]
+    err_counter = 0
+    
+    poti = potentiometer()
+    poti.open(conf)
+    
+    # test percentage values from 0 to 100 in steps of 10
+    for i in range(0, 110, 10):
+        err = poti.set(i)
+        if err != ErrorCode.errOk:
+            print(f"Error while set(): {err}")
+            err_counter += 1
+        print(f"Potentiometer set to {i}%.")
+        sleep(WAIT_BETWEEN_SET_GET)
+
+        # test values
+        data, err = poti.get(asDigital=True)
+        if err != ErrorCode.errOk:
+            print(f"Error while get(): {err}")
+            err_counter += 1
+        expected_val = Potentiometer._digitalize_resistance_value(i, resolution=conf["Potentiometer.resolution"])
+        actual_val = data
+        expected_val_percent = i
+        actual_val_percent = (data * 100) / (pot_steps - 1)
+        
+        if actual_val == expected_val:
+            print(f"Read value is correct.")
+        else:
+            print(f"VALUE NOT CORRECT: Potentiometer resistance value should be {expected_val} ({round(expected_val_percent, 1)}%) but is set to {actual_val} ({round(actual_val_percent, 1)}%)")
+        sleep(WAIT_BETWEEN_NEXT_TEST)
+    
+    # test resistance values from 0 to <max> in steps of 10% * <max>
+    for n in range(0, 110, 10):
+        i = (n/100) * conf["Potentiometer.resistance.max"]
+        err = poti.set(i, isAbsolute=True)
+        if err != ErrorCode.errOk:
+            print(f"Error while set(): {err}")
+            err_counter += 1
+        print(f"Potentiometer set to {i} Ohms.")
+        sleep(WAIT_BETWEEN_SET_GET)
+        
+        # test values
+        data, err = poti.get(asDigital=True)
+        if err != ErrorCode.errOk:
+            print(f"Error while get(): {err}")
+            err_counter += 1
+        expected_val = Potentiometer._digitalize_resistance_value(i, isAbsolute=True, max_resistance=conf["Potentiometer.resistance.max"], resolution=conf["Potentiometer.resolution"])
+        actual_val = data
+        expected_val_ohms = i
+        actual_val_ohms = data * (conf['Potentiometer.resistance.max'] / pot_steps)
+        
+        if actual_val == expected_val:
+            print(f"Read value is correct.")
+        else:
+            print(f"VALUE NOT CORRECT: Potentiometer resistance value should be {expected_val} ({round(actual_val_ohms)} ohms) but is set to {actual_val} ({round(actual_val_ohms)} ohms)")
+        sleep(WAIT_BETWEEN_NEXT_TEST)
+
+    print("Closing connection.")
+    poti.close()
+    print(f"Test finished with {err_counter} errors caught.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/testPotentiometer.py
+++ b/test/testPotentiometer.py
@@ -7,17 +7,17 @@ from philander.mcp40d import MCP40D as potentiometer
 from philander.potentiometer import Potentiometer
 from philander.primitives import Percentage
 
-WAIT_BETWEEN_SET_GET = .5
-WAIT_BETWEEN_NEXT_TEST = 2.5
+WAIT_BETWEEN_SET_GET = .1#.5
+WAIT_BETWEEN_NEXT_TEST = .1#2.5
 
 def main():
     conf = {
         "SerialBus.designator": "/dev/i2c-1",
         "SerialBusDevice.address": 0x2E,
         "Potentiometer.resistance.max": 100000,
-        "Potentiometer.resolution": 128
         } 
     err_counter = 0
+    poti_digital_max = 128
     
     poti = potentiometer()
     poti.open(conf)
@@ -39,7 +39,7 @@ def main():
         expected_val, _ = poti._digitalize_resistance_value(percentage=Percentage(i))
         actual_val = data
         expected_val_percent = i
-        actual_val_percent = data * (100/conf["Potentiometer.resolution"])
+        actual_val_percent = data * (100/poti_digital_max)
         
         if actual_val == expected_val:
             print(f"Read value is correct.")
@@ -65,12 +65,12 @@ def main():
         expected_val, _ = poti._digitalize_resistance_value(absolute=i)
         actual_val = data
         expected_val_ohms = i
-        actual_val_ohms = data * (conf['Potentiometer.resistance.max'] / conf["Potentiometer.resolution"])
+        actual_val_ohms = data * (conf['Potentiometer.resistance.max'] / poti_digital_max)
         
         if actual_val == expected_val:
             print(f"Read value is correct.")
         else:
-            print(f"VALUE NOT CORRECT: Potentiometer resistance value should be {expected_val} ({round(actual_val_ohms)} ohms) but is set to {actual_val} ({round(actual_val_ohms)} ohms)")
+            print(f"VALUE NOT CORRECT: Potentiometer resistance value should be {expected_val} ({round(expected_val_ohms)} ohms) but is set to {actual_val} ({round(actual_val_ohms)} ohms)")
         sleep(WAIT_BETWEEN_NEXT_TEST)
 
     print("Closing connection.")


### PR DESCRIPTION
+added abstract potentiometer class and explicit implementation of mcp40d17/18/19 digital potentiometer
+added (mostly) abstract test class which tests said potentiometer. The testclass can also be used directly for other potentiometer implementations by changing to the according import at the top of the test
+ some minor fixes for error output in testAccel
